### PR TITLE
GD search full width page title not using title from title/meta setting - FIXED

### DIFF
--- a/inc/geodirectory-compatibility.php
+++ b/inc/geodirectory-compatibility.php
@@ -298,3 +298,20 @@ function sd_archive_gd_map_shortcode( $shortcode ) {
 	return $shortcode;
 }
 add_filter( 'sd_archive_gd_map_shortcode', 'sd_archive_gd_map_shortcode', 10, 1 );
+
+/**
+ * Filter search page title on GD search page.
+ *
+ * @since 2.0.0.11
+ *
+ * @param string $title Search page title.
+ * @return string Filtered title.
+ */
+function sd_geodir_search_page_featured_area_title( $title ) {
+	if ( geodir_is_page( 'search' ) ) {
+		$title = the_title( '', '', false );
+	}
+
+	return $title;
+}
+add_filter( 'sd_featured_area_search_page_title', 'sd_geodir_search_page_featured_area_title', 10, 1 );

--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,9 @@ No, this is optional but recommended.
 
 == Changelog ==
 
+= 2.0.0.11 =
+* GD search full width page title not using title from title/meta setting - FIXED
+
 = 2.0.0.10 =
 * Click on Write a review link don't scroll to review form - FIXED
 * Featured area image not working when image is added via import post with image name only - FIXED


### PR DESCRIPTION
See https://wpgeodirectory.com/support/topic/bug-search-page-doesnt-pull-in-title-h1/